### PR TITLE
Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,10 @@ updates:
       - "/react"
     schedule:
       interval: "weekly"
+
+  # Update configuration for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/.github/workflows"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Noticed the actions used in the workflows here are outdated, proposing a Dependabot configuration to update - reference https://docs.github.com/en/actions/security-guides/using-githubs-security-features-to-secure-your-use-of-github-actions#keeping-the-actions-in-your-workflows-secure-and-up-to-date

Suggest enabling https://docs.github.com/en/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners#enabling-or-disabling-for-your-repository as well